### PR TITLE
Feat : 로그인 레이아웃 구현 및 공통 컴포넌트 생성

### DIFF
--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -5,11 +5,13 @@ import palette from '@/lib/styles/palette';
 import { typo } from '@/lib/styles/typo';
 import LoginForm from './LoginForm';
 import SocialLogin from './SocialLogin';
+import TabMenu from '../common/TabMenu';
+import Responsive from '../common/Responsive';
+import Title from '../common/atoms/Title';
 
 interface LoginProps {}
 
 const Login = (props: LoginProps) => {
-  console.log('');
   return (
     <LoginBlock>
       <LoginHeader>
@@ -18,20 +20,17 @@ const Login = (props: LoginProps) => {
         </Link>
       </LoginHeader>
       <LoginSection>
-        <Title>Login</Title>
+        <TabMenu />
         <LoginForm />
         <SocialLogin />
-        <RegisterWrapper>
+        <RegisterBlock>
           <Li>
             <Link to="/">회원가입</Link>
           </Li>
           <Li>
-            <span></span>
-          </Li>
-          <Li>
             <Link to="/">비밀번호 찾기</Link>
           </Li>
-        </RegisterWrapper>
+        </RegisterBlock>
       </LoginSection>
     </LoginBlock>
   );
@@ -60,19 +59,10 @@ const LoginHeader = styled.header`
 `;
 
 const LoginSection = styled.section`
-  padding: 0.5rem 3rem;
+  ${Responsive.ResponsiveWrapper}
 `;
 
-const Title = styled.h1`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 1.75rem;
-  font-size: ${typo.xLarge};
-  font-weight: 600;
-`;
-
-const RegisterWrapper = styled.div`
+const RegisterBlock = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -83,25 +73,29 @@ const Li = styled.li`
   display: flex;
   align-items: center;
   height: 1rem;
-  font-size: 15px;
+  font-size: ${typo.small};
   font-weight: 500;
   color: ${palette.black[100]};
 
   a {
-    padding: 0.75rem 1rem;
+    position: relative;
+    padding: 12px 16px;
   }
 
-  a:hover {
-    color: ${palette.primary.point};
+  &:hover {
+    text-decoration: underline;
   }
 
-  a:active {
-    color: ${palette.primary.point};
-  }
-
-  span {
-    width: 1px;
-    height: 100%;
-    background-color: ${palette.black[100]};
+  &:last-child {
+    a::before {
+      position: absolute;
+      content: '';
+      top: 50%;
+      left: 0;
+      width: 1px;
+      height: 14px;
+      transform: translateY(-45%);
+      background-color: ${palette.black[200]};
+    }
   }
 `;

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -1,5 +1,6 @@
-import palette from '@/lib/styles/palette';
 import styled from '@emotion/styled';
+import Input from '../common/atoms/Input';
+import Button from '../common/atoms/WideButton';
 
 interface LoginFormProps {}
 
@@ -9,9 +10,9 @@ const LoginForm = (props: LoginFormProps) => {
   };
   return (
     <Form onSubmit={handleSubmit}>
-      <InputId type="text" placeholder="아이디(이메일)" autoCapitalize="none" />
-      <InputPassword type="password" placeholder="비밀번호" autoCapitalize="none" />
-      <FormButton type="submit">로그인</FormButton>
+      <Input type={'text'} placeholder={'아이디(이메일)'} />
+      <Input type={'password'} placeholder={'비밀번호'} />
+      <Button>로그인</Button>
     </Form>
   );
 };
@@ -23,57 +24,5 @@ const Form = styled.form`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 0.75rem;
-  margin-top: 2rem;
-`;
-
-const InputId = styled.input`
-  width: 240px;
-  padding: 0.75rem 1rem;
-  border: 1px solid ${palette.grey[300]};
-  border-radius: 1.2rem;
-  font-size: 15px;
-
-  &::placehorder {
-    color: ${palette.black[200]};
-  }
-
-  &:focus {
-    border: 1px solid black;
-  }
-`;
-
-const InputPassword = styled.input`
-  width: 240px;
-  padding: 0.75rem 1rem;
-  border: 1px solid ${palette.grey[300]};
-  border-radius: 1.2rem;
-  font-size: 15px;
-
-  &::placehorder {
-    color: ${palette.black[200]};
-  }
-
-  &:focus {
-    border: 1px solid black;
-  }
-`;
-
-const FormButton = styled.button`
-  margin-top: 0.5rem;
-  padding: 0.75rem 1rem;
-  width: 240px;
-  border-radius: 1.2rem;
-  font-size: 15px;
-  font-weight: 500;
-  color: #fff;
-  background-color: ${palette.black[200]};
-
-  &:active {
-    color: #fff;
-  }
-
-  &:hover {
-    background-color: ${palette.primary.green};
-  }
+  margin-top: 16px;
 `;

--- a/src/components/Login/SocialLogin.tsx
+++ b/src/components/Login/SocialLogin.tsx
@@ -1,30 +1,31 @@
 import palette from '@/lib/styles/palette';
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 
 interface SocialLoginProps {}
 
 const SocialLogin = (props: SocialLoginProps) => {
   return (
-    <Block>
-      <Title>SNS 계정으로 로그인하기</Title>
-      <ButtonList>
-        <Button type="button">
+    <SocialLoginBlock>
+      <Title>SNS 계정으로 간편 로그인</Title>
+      <SocialLink>
+        <SLink to="/">
           <span>네이버 로그인</span>
-        </Button>
-        <Button type="button">
+        </SLink>
+        <SLink to="/">
           <span>카카오 로그인</span>
-        </Button>
-        <Button type="button">
+        </SLink>
+        <SLink to="/">
           <span>구글 로그인</span>
-        </Button>
-      </ButtonList>
-    </Block>
+        </SLink>
+      </SocialLink>
+    </SocialLoginBlock>
   );
 };
 
 export default SocialLogin;
 
-const Block = styled.div`
+const SocialLoginBlock = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -37,16 +38,16 @@ const Title = styled.h3`
   color: ${palette.grey[500]};
 `;
 
-const ButtonList = styled.div`
+const SocialLink = styled.div`
   display: flex;
   align-items: center;
-  margin-top: 1rem;
-  gap: 1rem;
+  margin-top: 16px;
 `;
 
-const Button = styled.button`
-  width: 3rem;
-  height: 3rem;
+const SLink = styled(Link)`
+  width: 3.2rem;
+  height: 3.2rem;
+  margin: 0 8px;
   border-radius: 50%;
   border: 1px solid ${palette.grey[300]};
 

--- a/src/components/common/TabMenu.tsx
+++ b/src/components/common/TabMenu.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import palette from '@/lib/styles/palette';
+import styled from '@emotion/styled';
+
+interface TabMenuProps {}
+
+const TabMenu = (props: TabMenuProps) => {
+  const [tabId, setTabId] = useState<number>(0);
+  const tabMenus = [
+    {
+      id: 0,
+      name: '일반 사용자',
+      title: 'user',
+    },
+    {
+      id: 1,
+      name: '판매자',
+      title: 'manager',
+    },
+  ];
+  return (
+    <TabMenuBlock>
+      {tabMenus.map(tab => (
+        <Tab key={tab.title} name={tab.title} focus={tabId === tab.id} onClick={() => setTabId(tab.id)}>
+          {tab.name}
+        </Tab>
+      ))}
+    </TabMenuBlock>
+  );
+};
+
+export default TabMenu;
+
+type tabStyleProps = {
+  name: string;
+  focus: boolean;
+};
+
+const TabMenuBlock = styled.ul`
+  display: flex;
+  justify-content: center;
+`;
+
+const Tab = styled.li<tabStyleProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 20px;
+  padding: 12px 0;
+  width: 140px;
+  border: 1px solid ${palette.black[100]};
+  border-radius: 10px 0 0 10px;
+  color: ${palette.black[100]};
+
+  ${({ name }) => name === 'manager' && `border-radius: 0 10px 10px 0;`};
+
+  ${({ focus }) =>
+    focus &&
+    `
+    background-color: ${palette.black[100]};
+    color: white;
+  `}
+`;

--- a/src/components/common/atoms/Input.tsx
+++ b/src/components/common/atoms/Input.tsx
@@ -1,0 +1,31 @@
+import palette from '@/lib/styles/palette';
+import { typo } from '@/lib/styles/typo';
+import styled from '@emotion/styled';
+
+interface InputProps {
+  type: string;
+  placeholder: string;
+}
+
+const Input = ({ type, placeholder }: InputProps) => {
+  return <SInput type={type} placeholder={placeholder} autoCapitalize="false" />;
+};
+
+export default Input;
+
+const SInput = styled.input`
+  width: 280px;
+  margin-top: 16px;
+  padding: 12px 16px;
+  border: 1px solid ${palette.grey[300]};
+  border-radius: 10px;
+  font-size: ${typo.base};
+
+  &::placeholder {
+    color: ${palette.grey[400]};
+  }
+
+  &:focus {
+    border: 1px solid ${palette.black[200]};
+  }
+`;

--- a/src/components/common/atoms/Title.tsx
+++ b/src/components/common/atoms/Title.tsx
@@ -1,0 +1,19 @@
+import { typo } from '@/lib/styles/typo';
+import styled from '@emotion/styled';
+
+interface TitleProps {
+  children: React.ReactNode;
+  fontSize: string;
+}
+
+const Title = ({ children, fontSize }: TitleProps) => {
+  return <STitle fontSize={fontSize}>{children}</STitle>;
+};
+
+export default Title;
+
+const STitle = styled.h1<{ fontSize: string }>`
+  margin-top: 20px;
+  margin-left: 16px;
+  ${({ fontSize }) => fontSize && `font-size: ${fontSize}`}
+`;

--- a/src/components/common/atoms/WideButton.tsx
+++ b/src/components/common/atoms/WideButton.tsx
@@ -1,0 +1,30 @@
+import palette from '@/lib/styles/palette';
+import { typo } from '@/lib/styles/typo';
+import styled from '@emotion/styled';
+
+interface ButtonProps {
+  children: React.ReactNode;
+}
+
+const Button = ({ children }: ButtonProps) => {
+  return <SButton type="submit">{children}</SButton>;
+};
+
+export default Button;
+
+const SButton = styled.button`
+  margin-top: 16px;
+  padding: 12px 16px;
+  width: 280px;
+  border-radius: 10px;
+  font-size: ${typo.base};
+  font-weight: 500;
+  color: #fff;
+  background-color: ${palette.black[100]};
+  cursor: pointer;
+
+  &:active {
+    color: #fff;
+    background-color: ${palette.black[200]};
+  }
+`;


### PR DESCRIPTION
# Feat : 로그인 레이아웃 구현 및 공통 컴포넌트 생성

### 일반사용자 - 판매자 로그인 탭 메뉴 구현
- 회원가입 시에도 TabMenu 컴포넌트가 사용되므로 재사용성을 위해 commons 디렉토리에 생성
- useState로 상태 관리

### 레이아웃 수정
- Login 컴포넌트 레이아웃 수정

### atomic component
- 자주 사용될 h1, Button, Input 태그 컴포넌트화
- atoms 디렉토리 추가 (src/components/atoms)

