### PR TITLE
Feat : SignUp 컴포넌트 구현, 스타일링 및 atoms 디렉토리 내 컴포넌트 수정

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import Navbar from './Navbar';
 import palette from '@/lib/styles/palette';
 import PATH from '@/constants/path';
 import usePathHeaderOnlyLogo from '@/hooks/usePathHeaderOnlyLogo';
+import { useGoBack } from '@/hooks/useGoBack';
 
 interface HomeProps {}
 
@@ -15,6 +16,7 @@ const Header = (props: HomeProps) => {
   const [isActive, setIsActive] = useState(false);
   const checkHeader = usePathHeaderOnlyLogo();
 
+  const goBack = useGoBack();
   const handleChangeIsActive = () => {
     setIsActive(!isActive);
   };
@@ -22,10 +24,12 @@ const Header = (props: HomeProps) => {
   return (
     <HeaderBlock>
       {checkHeader ? (
-        '<'
+        <GoBackIconBlock onClick={() => goBack()}>
+          <i className="fa-solid fa-arrow-left" />
+        </GoBackIconBlock>
       ) : (
         <ToggleMenuBar onClick={handleChangeIsActive}>
-          <i className="fa-solid fa-bars"></i>
+          <i className="fa-solid fa-bars" />
         </ToggleMenuBar>
       )}
       <LogoBlock>
@@ -56,6 +60,18 @@ const HeaderBlock = styled.nav`
   }
 
   ${Responsive.ResponsiveWrapper}
+`;
+
+const GoBackIconBlock = styled.span`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 28px;
+  height: 28px;
+
+  i {
+    font-size: 20px;
+  }
 `;
 
 const ToggleMenuBar = styled.div`

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import { ReactComponent as NavbarLogo } from '@/assets/esc-logo.svg';
@@ -48,6 +48,7 @@ const Header = (props: HomeProps) => {
 };
 
 const HeaderBlock = styled.nav`
+  position: relative;
   display: flex;
   height: 80px;
   background-color: #fff;
@@ -82,17 +83,34 @@ const ToggleMenuBar = styled.div`
 `;
 
 const LogoBlock = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: absolute;
-  left: 49%;
-  top: 55%;
-  transform: translate(-50%, -50%);
+  left: 50%;
+  transform: translateX(-50%);
+  cursor: pointer;
+
+  a {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+  }
 `;
 
 const UserMenu = styled.div`
-  li:hover {
-    background-color: ${palette.primary['point']};
-    color: #fff;
-    transition: all 0.2s ease-in-out;
+  border: 1px solid ${palette.grey[300]};
+  border-radius: 10px;
+
+  &:hover {
+    background-color: ${palette.grey[100]};
+  }
+
+  a {
+    display: inline-block;
+    padding: 0.25rem 0.2rem;
   }
 `;
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -24,7 +24,7 @@ const Header = (props: HomeProps) => {
   return (
     <HeaderBlock>
       {checkHeader ? (
-        <GoBackIconBlock onClick={() => goBack()}>
+        <GoBackIconBlock onClick={goBack}>
           <i className="fa-solid fa-arrow-left" />
         </GoBackIconBlock>
       ) : (

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,3 +1,5 @@
+import { RootState } from '@/store/store';
+import { useSelector } from 'react-redux';
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 import palette from '@/lib/styles/palette';
@@ -10,33 +12,31 @@ import Responsive from '../common/Responsive';
 interface LoginProps {}
 
 const Login = (props: LoginProps) => {
+  const userId = useSelector((state: RootState) => state.userslice.userId);
+
   return (
     <LoginBlock>
-      <LoginSection>
-        <TabMenu />
-        <LoginForm />
-        <SocialLogin />
-        <RegisterBlock>
-          <Li>
-            <Link to="/signup">회원가입</Link>
-          </Li>
-          <Li>
-            <Link to="/">비밀번호 찾기</Link>
-          </Li>
-        </RegisterBlock>
-      </LoginSection>
+      <TabMenu />
+      <LoginForm />
+      {userId === 0 && <SocialLogin />}
+      <RegisterBlock>
+        <Li>
+          <Link to="/signup">회원가입</Link>
+        </Li>
+        <Li>
+          <Link to="/">비밀번호 찾기</Link>
+        </Li>
+      </RegisterBlock>
     </LoginBlock>
   );
 };
 
 export default Login;
 
-const LoginBlock = styled.div`
+const LoginBlock = styled.section`
+  position: relative;
   width: 100%;
   height: 100vh;
-`;
-
-const LoginSection = styled.section`
   ${Responsive.ResponsiveWrapper}
 `;
 
@@ -45,6 +45,7 @@ const RegisterBlock = styled.div`
   justify-content: center;
   align-items: center;
   margin-top: 3rem;
+  width: 100%;
 `;
 
 const Li = styled.li`

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,6 +1,6 @@
 import { RootState } from '@/store/store';
-import { useSelector } from 'react-redux';
 import styled from '@emotion/styled';
+import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import palette from '@/lib/styles/palette';
 import { typo } from '@/lib/styles/typo';
@@ -36,7 +36,6 @@ export default Login;
 const LoginBlock = styled.section`
   position: relative;
   width: 100%;
-  height: 100vh;
   ${Responsive.ResponsiveWrapper}
 `;
 

--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -1,3 +1,4 @@
+import palette from '@/lib/styles/palette';
 import styled from '@emotion/styled';
 import Button from '../common/atoms/Button';
 import Input from '../common/atoms/Input';
@@ -11,19 +12,19 @@ const LoginForm = (props: LoginFormProps) => {
 
   const handleButtonClick = () => {};
   return (
-    <Form onSubmit={handleSubmit}>
+    <FormBlock onSubmit={handleSubmit}>
       <Input type={'text'} placeholder={'아이디(이메일)'} />
       <Input type={'password'} placeholder={'비밀번호'} />
-      <Button type={'submit'} size={'large'} onClick={handleButtonClick}>
+      <Button type={'submit'} size={'large'} backgroundColor={`${palette.black[100]}`} onClick={handleButtonClick}>
         로그인
       </Button>
-    </Form>
+    </FormBlock>
   );
 };
 
 export default LoginForm;
 
-const Form = styled.form`
+const FormBlock = styled.form`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -1,5 +1,3 @@
-import { Link } from 'react-router-dom';
-import { ReactComponent as NavbarLogo } from '@/assets/esc-logo.svg';
 import styled from '@emotion/styled';
 import palette from '@/lib/styles/palette';
 import Responsive from '../common/Responsive';
@@ -10,42 +8,18 @@ import TabMenu from '../common/TabMenu';
 const SignUp = () => {
   return (
     <SignUpBlock>
-      <SignUpHeader>
-        <Link to="/">
-          <NavbarLogo width="80px" height="80px" />
-        </Link>
-      </SignUpHeader>
-      <SignUpSection>
-        <Title fontSize={`${typo.large}`}>회원가입</Title>
-        <TabMenu />
-        <ImgBlock>
-          <Img src="" alt="프로필" />
-        </ImgBlock>
-      </SignUpSection>
+      <Title fontSize={`${typo.large}`}>회원가입</Title>
+      <TabMenu />
+      <ImgBlock>
+        <Img src="" alt="프로필" />
+      </ImgBlock>
     </SignUpBlock>
   );
 };
 
 export default SignUp;
 
-const SignUpBlock = styled.div``;
-
-const SignUpHeader = styled.header`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 0.5rem 3rem;
-  border-bottom: 1px solid ${palette.grey[100]};
-  box-shadow: 0px 0px 16px rgba(0, 0, 0, 0.125);
-  background-color: #fff;
-
-  a {
-    display: flex;
-    align-items: center;
-  }
-`;
-
-const SignUpSection = styled.section`
+const SignUpBlock = styled.section`
   ${Responsive.ResponsiveWrapper}
 `;
 

--- a/src/components/SignUp/SignUp.tsx
+++ b/src/components/SignUp/SignUp.tsx
@@ -4,6 +4,7 @@ import Responsive from '../common/Responsive';
 import { typo } from '@/lib/styles/typo';
 import Title from '../common/atoms/Title';
 import TabMenu from '../common/TabMenu';
+import SignUpForm from './SignUpForm';
 
 const SignUp = () => {
   return (
@@ -11,8 +12,12 @@ const SignUp = () => {
       <Title fontSize={`${typo.large}`}>회원가입</Title>
       <TabMenu />
       <ImgBlock>
-        <Img src="" alt="프로필" />
+        <Img src="/" alt="프로필" />
+        <PlusButton>
+          <i className="fa-solid fa-plus"></i>
+        </PlusButton>
       </ImgBlock>
+      <SignUpForm />
     </SignUpBlock>
   );
 };
@@ -20,12 +25,13 @@ const SignUp = () => {
 export default SignUp;
 
 const SignUpBlock = styled.section`
+  overflow: scroll;
   ${Responsive.ResponsiveWrapper}
 `;
 
 const ImgBlock = styled.div`
   position: relative;
-  margin: 20px auto 0;
+  margin: 40px auto 0;
   width: 120px;
   height: 120px;
   background-color: ${palette.grey[200]};
@@ -33,8 +39,20 @@ const ImgBlock = styled.div`
 `;
 
 const Img = styled.img`
-  display: inline-block;
   width: 100%;
   height: 100%;
+  border-radius: 50%;
   object-fit: contain;
+`;
+
+const PlusButton = styled.button`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: transparent;
+
+  i {
+    font-size: 24px;
+  }
 `;

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+import { useGoBack } from '@/hooks/useGoBack';
+import { useNavigate } from 'react-router';
+import palette from '@/lib/styles/palette';
+import { typo } from '@/lib/styles/typo';
+import styled from '@emotion/styled';
+import Button from '../common/atoms/Button';
+import Input from '../common/atoms/Input';
+import Label from '../common/atoms/Label';
+
+interface SignUpFormProps {}
+
+const SignUpForm = (props: SignUpFormProps) => {
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+  };
+
+  const [overlapEmail, setOverlapEmail] = useState(true);
+  const handleEmailDoubleCheck = () => {
+    setTimeout(() => {
+      setOverlapEmail(false);
+    }, 1000);
+  };
+
+  const goBack = useGoBack();
+  const navigate = useNavigate();
+
+  return (
+    <FormBlock onSubmit={handleFormSubmit}>
+      <SWrapper>
+        <EmailBlock>
+          <Label htmlFor={'email'}>이메일</Label>
+          <DoubleCheckButton
+            type="button"
+            size={'small'}
+            color={`${palette.grey[500]}`}
+            backgroundColor={`${palette.grey[200]}`}
+            onClick={handleEmailDoubleCheck}
+          >
+            중복검사
+          </DoubleCheckButton>
+        </EmailBlock>
+        <Input type="email" id="email" placeholder="example.email.com" />
+      </SWrapper>
+      <Button
+        type="button"
+        size={'large'}
+        backgroundColor={overlapEmail ? `${palette.grey[200]}` : `${palette.black[100]}`}
+        onClick={() => {}}
+      >
+        인증하기
+      </Button>
+      <SWrapper>
+        <Label htmlFor={'password'}>비밀번호</Label>
+        <Desc>영문, 숫자를 포함한 8자 이상을 입력해주세요.</Desc>
+        <Input type="password" id="password" placeholder="비밀번호" />
+      </SWrapper>
+      <SWrapper>
+        <Label htmlFor={'passwordConfirm'}>비밀번호 확인</Label>
+        <Input type="password" id="passwordConfirm" placeholder="비밀번호 확인" />
+      </SWrapper>
+      <SWrapper>
+        <Label htmlFor={'nickname'}>이메일</Label>
+        <Desc>다른 유저와 겹치지 않도록 입력해주세요 (2 ~ 15자)</Desc>
+        <Input type="text" id="nickname" placeholder="닉네임 입력" />
+      </SWrapper>
+      <StyleWrapper>
+        <Button type="submit" size={'large'} backgroundColor={`${palette.black[100]}`} onClick={() => navigate('/')}>
+          회원가입하기
+        </Button>
+      </StyleWrapper>
+      <QuestionDesc>
+        이미 아이디가 있으신가요? <span onClick={goBack}>로그인</span>
+      </QuestionDesc>
+    </FormBlock>
+  );
+};
+
+export default SignUpForm;
+
+const FormBlock = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+`;
+
+const SWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-top: 8px;
+  gap: 8px;
+`;
+
+const EmailBlock = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const DoubleCheckButton = styled(Button)`
+  border: 1px solid black;
+`;
+
+const Desc = styled.p`
+  font-size: ${typo.micro};
+  color: ${palette.black[200]};
+`;
+
+const StyleWrapper = styled.div`
+  margin-top: 2rem;
+`;
+
+const QuestionDesc = styled.p`
+  margin-bottom: 3rem;
+  font-size: ${typo.small};
+  color: ${palette.grey[500]};
+  span {
+    font-weight: 600;
+    text-decoration: underline;
+    color: ${palette.black[200]};
+  }
+`;

--- a/src/components/common/TabMenu.tsx
+++ b/src/components/common/TabMenu.tsx
@@ -1,16 +1,19 @@
-import { useState } from 'react';
 import palette from '@/lib/styles/palette';
 import styled from '@emotion/styled';
 import { tabMenus } from '@/constants/tabMenu';
+import { useSelector } from 'react-redux';
+import { RootState, useAppDispatch } from '@/store/store';
+import { changeUser } from '@/store/userSlice';
 
 interface TabMenuProps {}
 
 const TabMenu = (props: TabMenuProps) => {
-  const [tabId, setTabId] = useState<number>(0);
+  const userId = useSelector((state: RootState) => state.userslice.userId);
+  const dispatch = useAppDispatch();
   return (
     <TabMenuBlock>
       {tabMenus.map(tab => (
-        <Tab key={tab.title} name={tab.title} focus={tabId === tab.id} onClick={() => setTabId(tab.id)}>
+        <Tab key={tab.title} name={tab.title} focus={userId === tab.id} onClick={() => dispatch(changeUser(tab.id))}>
           {tab.name}
         </Tab>
       ))}

--- a/src/components/common/TabMenu.tsx
+++ b/src/components/common/TabMenu.tsx
@@ -1,23 +1,12 @@
 import { useState } from 'react';
 import palette from '@/lib/styles/palette';
 import styled from '@emotion/styled';
+import { tabMenus } from '@/constants/tabMenu';
 
 interface TabMenuProps {}
 
 const TabMenu = (props: TabMenuProps) => {
   const [tabId, setTabId] = useState<number>(0);
-  const tabMenus = [
-    {
-      id: 0,
-      name: '일반 사용자',
-      title: 'user',
-    },
-    {
-      id: 1,
-      name: '판매자',
-      title: 'manager',
-    },
-  ];
   return (
     <TabMenuBlock>
       {tabMenus.map(tab => (

--- a/src/components/common/atoms/Button.tsx
+++ b/src/components/common/atoms/Button.tsx
@@ -9,7 +9,9 @@ interface ButtonProps {
   children: React.ReactNode;
   type: ButtonType;
   size: SizeList;
-  onClick: () => void;
+  color?: string;
+  backgroundColor: string;
+  onClick?: () => void;
 }
 
 type SizeList = 'large' | 'medium' | 'small';
@@ -32,9 +34,9 @@ const sizeStyle = {
   `,
 };
 
-const Button = ({ children, type, size, onClick }: ButtonProps) => {
+const Button = ({ children, type, size, color, backgroundColor, onClick }: ButtonProps) => {
   return (
-    <SButton type={type} size={size} onClick={onClick}>
+    <SButton type={type} size={size} color={color} backgroundColor={backgroundColor} onClick={onClick}>
       {children}
     </SButton>
   );
@@ -45,12 +47,11 @@ export default Button;
 const SButton = styled.button<CSSProperties & { size: SizeList }>`
   border-radius: 10px;
   font-weight: 500;
-  color: #fff;
-  background-color: ${palette.black[100]};
+  color: ${props => (props.color ? props.color : '#fff')};
+  background-color: ${props => props.backgroundColor};
   cursor: pointer;
 
   &:active {
-    color: #fff;
     background-color: ${palette.black[200]};
   }
 

--- a/src/components/common/atoms/Input.tsx
+++ b/src/components/common/atoms/Input.tsx
@@ -5,10 +5,11 @@ import styled from '@emotion/styled';
 interface InputProps {
   type: string;
   placeholder: string;
+  id?: string;
 }
 
-const Input = ({ type, placeholder }: InputProps) => {
-  return <SInput type={type} placeholder={placeholder} autoCapitalize="false" />;
+const Input = ({ type, placeholder, id }: InputProps) => {
+  return <SInput type={type} id={id} placeholder={placeholder} autoCapitalize="false" />;
 };
 
 export default Input;
@@ -26,5 +27,6 @@ const SInput = styled.input`
 
   &:focus {
     border: 1px solid ${palette.black[200]};
+    background-color: ${palette.grey[100]};
   }
 `;

--- a/src/components/common/atoms/Label.tsx
+++ b/src/components/common/atoms/Label.tsx
@@ -1,0 +1,23 @@
+import palette from '@/lib/styles/palette';
+import { typo } from '@/lib/styles/typo';
+import styled from '@emotion/styled';
+import { Children } from 'react';
+
+interface LabelProps {
+  children: React.ReactNode;
+  htmlFor: string;
+}
+
+const Label = ({ children, htmlFor }: LabelProps) => {
+  return <SLabel htmlFor={htmlFor}>{children}</SLabel>;
+};
+
+export default Label;
+
+const SLabel = styled.label`
+  font-size: ${typo.base};
+  font-weight: 400;
+  line-height: ${typo.medium};
+  color: ${palette.black[200]};
+  word-break: keep-all;
+`;

--- a/src/components/common/atoms/Title.tsx
+++ b/src/components/common/atoms/Title.tsx
@@ -14,6 +14,6 @@ export default Title;
 
 const STitle = styled.h1<{ fontSize: string }>`
   margin-top: 20px;
-  margin-left: 16px;
+  margin-left: 20px;
   ${({ fontSize }) => fontSize && `font-size: ${fontSize}`}
 `;

--- a/src/constants/tabMenu.ts
+++ b/src/constants/tabMenu.ts
@@ -1,0 +1,12 @@
+export const tabMenus = [
+  {
+    id: 0,
+    name: '일반 사용자',
+    title: 'user',
+  },
+  {
+    id: 1,
+    name: '판매자',
+    title: 'manager',
+  },
+];

--- a/src/hooks/useGoBack.ts
+++ b/src/hooks/useGoBack.ts
@@ -1,0 +1,10 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router';
+
+export const useGoBack = () => {
+  const navigate = useNavigate();
+  const goBack = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+  return goBack;
+};

--- a/src/lib/styles/GlobalStyle.tsx
+++ b/src/lib/styles/GlobalStyle.tsx
@@ -9,9 +9,25 @@ const style = css`
     line-height: 1.5;
   }
 
-  html {
+  html,
+  body {
     width: 100%;
     height: 100%;
+    font-size: 16px;
+    scroll-behavior: smooth;
+  }
+
+  main,
+  section {
+    ::-webkit-scrollbar {
+      display: none;
+    }
+    ::-webkit-scrollbar-thumb {
+      background-color: transparent;
+    }
+    ::-webkit-scrollbar-track {
+      background-color: transparent;
+    }
   }
 
   h1 {
@@ -50,6 +66,9 @@ const style = css`
   li {
     list-style: none;
     padding-left: 0;
+  }
+  :root {
+    --vh: 100%;
   }
 `;
 

--- a/src/lib/styles/palette.ts
+++ b/src/lib/styles/palette.ts
@@ -5,7 +5,7 @@ export const black = {
 
 export const grey = {
   '100': '#f7f8fa',
-  '200': '#e0e2e7',
+  '200': '#dadada',
   '300': '#b2b3b9',
   '400': '#8c8d96',
   '500': '#565B60',

--- a/src/lib/utils/setMobileScreenSize.ts
+++ b/src/lib/utils/setMobileScreenSize.ts
@@ -1,0 +1,4 @@
+export const setScreenSize = () => {
+  let vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty('--vh', `${vh}px`);
+};

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -26,6 +26,8 @@ const HeaderWrapper = styled.header`
   z-index: 9999;
 `;
 
-const MainWrapper = styled.main``;
+const MainWrapper = styled.main`
+  padding-top: 5rem;
+`;
 
 export default Layout;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,8 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { useDispatch } from 'react-redux';
+import { userReducer } from './userSlice';
 
 export const store = configureStore({
-  reducer: {},
+  reducer: {
+    userslice: userReducer,
+  },
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/store/userSlice.ts
+++ b/src/store/userSlice.ts
@@ -1,0 +1,15 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export const userSlice = createSlice({
+  name: 'userSlice',
+  initialState: { userId: 0 },
+  reducers: {
+    changeUser: (state, action) => {
+      state.userId = action.payload;
+    },
+  },
+});
+
+export const { changeUser } = userSlice.actions;
+
+export const userReducer = userSlice.reducer;


### PR DESCRIPTION
# Feat : SignUp 컴포넌트 구현, 스타일링 및 atoms 디렉토리 내 컴포넌트 수정

1. GlobalStyle.tsx, palette.tsx
- 모바일 환경에서 스크롤이 안되는 이슈가 있어, 일부 스타일 변경
- grey[200] 컬러 수정


2. utils/setMobileScreenSize.ts
- 모바일 100vh, 사파리, 일부 모바일 환경에서 높이가 꽉차지 않는 문제 해결을 위한 유틸함수 생성


3. store/userSlice.ts
- 일반 사용자, 판매자의 상태, 전역 상태로 관리하기 위해 slice 생성


4. TabMenu.tsx
- userSlice를 이용해 탭 메뉴 클릭 시 user의 상태를 확인
- constants 폴더로 상수 분리


5. layout 컴포넌트 main Wrapper
- padding-top: 5rem 추가


7. Header.tsx
- logo 중앙정렬 이슈 해결
- 로그인 링크 버튼 스타일링 변경
- 뒤로가기 버튼 추가


8. atoms/Button.tsx, atoms/Input.tsx
- 스타일링을 위한 props 일부 optional, 또는 필수 props로 재지정


9. atoms/Label.tsx
- 작은 제목 역할로 재사용 빈도가 높아질 것으로 예상되어 생성


10. Login, SignUp 페이지(라우트)
- Header, home 페이지와 같은 헤더를 사용하도록, layout 컴포넌트 하위에 이동


11. SignUp 컴포넌트 레이아웃 구현
- SignUp 컴포넌트 내 form에 관련된 내용들 SignUpForm 컴포넌트로 분리


12. Title 컴포넌트
- margin-left 수정