### PR TITLE
Refactor : EmptyItemNotification 추상화 작업

### DIFF
--- a/src/api/stadiumApi.ts
+++ b/src/api/stadiumApi.ts
@@ -47,6 +47,7 @@ export interface DetailStadiumResponse {
 }
 
 interface LikeStadium {
+  id: number;
   stadiumId: number;
   name: string;
   address: string;
@@ -146,6 +147,7 @@ export const stadiumApi = baseApi.injectEndpoints({
         url: `/stadiums/likelist`,
         method: 'GET',
       }),
+      providesTags: ['User'],
     }),
     getRentalStadiumList: builder.query<RentalStadiumListResponse, string>({
       query: () => ({

--- a/src/components/CardStadium/CardStadium.tsx
+++ b/src/components/CardStadium/CardStadium.tsx
@@ -12,18 +12,22 @@ import StatusTag from './StatusTag';
 interface CardStadiumProps {
   stadium: RentalStadium;
   currentLocation: string;
+  refetch?: any;
 }
 
-const CardStadium = ({ stadium, currentLocation }: CardStadiumProps) => {
+const CardStadium = ({ stadium, currentLocation, refetch }: CardStadiumProps) => {
   const [stadiumLike, setStadiumLike] = useState<boolean>(true);
   const { stadiumId, name, address, starAvg, imgUrl, status } = stadium;
 
   const navigate = useNavigate();
 
   const [postLikeStadiumAPI] = usePostLikeStadiumMutation();
-  const likeCallbackAPI = useThrottleRef(() => postLikeStadiumAPI(String(stadiumId)));
+  const likeCallbackAPI = useThrottleRef(async () => {
+    await postLikeStadiumAPI(String(stadiumId));
+    refetch();
+  });
 
-  const handleChangeStadiumLike = () => {
+  const handleChangeStadiumLike = async () => {
     setStadiumLike(false);
     likeCallbackAPI();
   };

--- a/src/components/MainBasicUser/MarkerStadiumInfo.tsx
+++ b/src/components/MainBasicUser/MarkerStadiumInfo.tsx
@@ -4,7 +4,8 @@ import palette from '@/lib/styles/palette';
 import { typo } from '@/lib/styles/typo';
 import { useNavigate } from 'react-router-dom';
 import PATH from '@/constants/path';
-import { SearchStadiumContent } from '@/api/stadiumApi';
+import { SearchStadiumContent, usePostLikeStadiumMutation } from '@/api/stadiumApi';
+import useThrottleRef from '@/hooks/useThrottleRef';
 
 interface MarkerStadiumInfoProps {
   markerInfo: SearchStadiumContent;
@@ -14,10 +15,12 @@ const MarkerStadiumInfo = ({ markerInfo }: MarkerStadiumInfoProps) => {
   const [stadiumLike, setStadiumLike] = useState(false);
   const navigate = useNavigate();
 
-  const handleChangeStadiumLike = () => {
-    // 찜하기 logic 작성
+  const [postLikeStadiumAPI] = usePostLikeStadiumMutation();
+  const likeCallbackAPI = useThrottleRef(() => postLikeStadiumAPI(String(markerInfo.id)));
 
-    setStadiumLike(!stadiumLike);
+  const handleChangeStadiumLike = () => {
+    setStadiumLike(true);
+    likeCallbackAPI();
   };
 
   const toUploadNavigate = () => {

--- a/src/components/MeLikeStadium/MeLikeStadium.tsx
+++ b/src/components/MeLikeStadium/MeLikeStadium.tsx
@@ -1,6 +1,8 @@
 import { useGetLikeStadiumListQuery } from '@/api/stadiumApi';
+import PATH from '@/constants/path';
 import media from '@/lib/styles/media';
 import { typo } from '@/lib/styles/typo';
+import sw from '@/lib/utils/customSweetAlert';
 import styled from '@emotion/styled';
 import { useEffect } from 'react';
 import { useLocation } from 'react-router';
@@ -15,15 +17,17 @@ interface MeLikeStadiumProps {}
 
 const MeLikeStadium = ({}: MeLikeStadiumProps) => {
   const location = useLocation();
-  const { data, isLoading, error } = useGetLikeStadiumListQuery('');
-  const likeStadiumList = data?.content;
+  const { data, isLoading, error, refetch } = useGetLikeStadiumListQuery('', {
+    refetchOnMountOrArgChange: true,
+  });
 
-  // stadium.stadiumId 수정하기
-  useEffect(() => {
-    if (error) {
-      console.error('잘못된 요청입니다.');
-    }
-  }, [error]);
+  const likeStadiumList = data?.content;
+  console.log(likeStadiumList);
+
+  if (error) {
+    sw.toast.error('잘못된 요청입니다.');
+    console.error('잘못된 요청입니다.');
+  }
 
   if (isLoading || !data) {
     return <Loading />;
@@ -36,14 +40,19 @@ const MeLikeStadium = ({}: MeLikeStadiumProps) => {
           찜한 체육관
         </Title>
       </TitleWrapper>
-      {likeStadiumList ? (
+      {likeStadiumList!.length > 0 ? (
         <LikeStadiumList>
-          {likeStadiumList.map(stadium => (
-            <CardStadium key={stadium.name} stadium={stadium} currentLocation={location.pathname} />
+          {likeStadiumList!.map(stadium => (
+            <CardStadium key={stadium.name} stadium={stadium} currentLocation={location.pathname} refetch={refetch} />
           ))}
         </LikeStadiumList>
       ) : (
-        <EmptyItemNotification message="찜한 체육관이 없습니다" />
+        <EmptyItemNotification
+          message="찜한 체육관이 없습니다"
+          btnActive={true}
+          btnText={'체육관 보러가기'}
+          path={PATH.ROOT}
+        />
       )}
       <StyledPadding />
     </MeLikeStadiumBlock>

--- a/src/components/MeRecentSearch/MeRecentSearch.tsx
+++ b/src/components/MeRecentSearch/MeRecentSearch.tsx
@@ -1,10 +1,11 @@
+import PATH from '@/constants/path';
 import media from '@/lib/styles/media';
 import { typo } from '@/lib/styles/typo';
 import { CurrentStadium, getAccessStadium } from '@/lib/utils/accessStadium';
 import styled from '@emotion/styled';
 import CardStadium from '../CardStadium/CardStadium';
 import Title from '../common/atoms/Title';
-import EmptyItem from '../common/EmptyItemNotification';
+import EmptyItemNotification from '../common/EmptyItemNotification';
 import Responsive from '../common/Responsive';
 import StyledPadding from '../common/StyledPadding';
 
@@ -27,7 +28,12 @@ const MeRecentSearch = ({}: MeRecentSearchProps) => {
           ))}
         </RecentSearchList>
       ) : (
-        <EmptyItem message="최근 본 체육관이 없습니다" />
+        <EmptyItemNotification
+          message="최근 본 체육관이 없습니다"
+          btnActive={true}
+          btnText={'체육관 보러가기'}
+          path={PATH.ROOT}
+        />
       )}
       <StyledPadding />
     </MeRecentSearchBlock>

--- a/src/components/common/EmptyItemNotification.tsx
+++ b/src/components/common/EmptyItemNotification.tsx
@@ -1,5 +1,4 @@
 import { DEFAULT_ICONURL } from '@/constants/defaultImage';
-import PATH from '@/constants/path';
 import palette from '@/lib/styles/palette';
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router';
@@ -7,23 +6,28 @@ import Button from './atoms/Button';
 
 interface EmptyItemProps {
   message: string;
+  btnActive: boolean;
+  btnText?: string;
+  path?: string;
 }
 
-const EmptyItemNotification = ({ message }: EmptyItemProps) => {
+const EmptyItemNotification = ({ message, btnActive, btnText, path }: EmptyItemProps) => {
   const navigate = useNavigate();
   return (
     <EmptyItemNotificationBlock>
       <img src={DEFAULT_ICONURL} alt="스마일" />
       <EmptyDesc>{message}</EmptyDesc>
-      <Button
-        type={'button'}
-        size={'large'}
-        backgroundColor={`${palette.primary['green']}`}
-        onClick={() => navigate(`${PATH.ROOT}`)}
-      >
-        체육관 보러가기
-        <ArrowIcon className="fa-solid fa-location-arrow" />
-      </Button>
+      {btnActive && (
+        <Button
+          type={'button'}
+          size={'large'}
+          backgroundColor={`${palette.primary['green']}`}
+          onClick={() => navigate(path!)}
+        >
+          {btnText}
+          <ArrowIcon className="fa-solid fa-location-arrow" />
+        </Button>
+      )}
     </EmptyItemNotificationBlock>
   );
 };

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -39,12 +39,13 @@ const HeaderWrapper = styled.header`
 `;
 
 const MainWrapper = styled.main`
+  height: calc(100% - 240px);
   padding-top: 5rem;
 `;
 
 const FooterWrapper = styled.footer<{ userType: 'USER' | 'MANAGER' }>`
   ${media.xsmallMin} {
-    margin-top: 12rem;
+    margin-top: 5rem;
   }
 `;
 export default Layout;


### PR DESCRIPTION
# Refactor : EmptyItemNotification 추상화 작업


## 구체적인 내용
- LikeStadium 응답 id, stadiumId로 구분
- MeLikeStadium 컴포넌트에서 찜하기 해제 기능 추가 및 refetch 연동
- Home 페이지 체육관 클릭 후 뜨는 체육관 정보 북마크 기능 추가
- FooterWrapper margin 수정 및 MainWrapper Height 설정
- EmptyItemNotification 추상화 작업 및 활용하는 컴포넌트에 반영